### PR TITLE
Fixes #1626 Autocomplete not clickable on mobile if rendered below virtual keyboard

### DIFF
--- a/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
+++ b/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
@@ -278,7 +278,7 @@ define([
                         }
 
                         this.responseList.indexList
-                            .on('click', function (e) {
+                            .on('click vclick', function (e) {
                                 self.responseList.selected = $(this);
                                 if (self.responseList.selected.attr("href")) {
                                     window.location.href = self.responseList.selected.attr("href");


### PR DESCRIPTION
All details on my comment in issue https://github.com/Smile-SA/elasticsuite/issues/1626#issuecomment-732350477